### PR TITLE
Updating librecores-ci-openrisc to remove cores required by or1k-tests

### DIFF
--- a/librecores-ci-openrisc/Dockerfile
+++ b/librecores-ci-openrisc/Dockerfile
@@ -18,10 +18,4 @@ ENV PATH="/tmp/tools/or1k-elf/bin:${PATH}"
 # Download and compile or1k-tests
 RUN git clone https://github.com/openrisc/or1k-tests.git 
 WORKDIR /tmp/src/tools/or1k-tests/native
-RUN make -j8
-
-# Setup fusesoc and add the cores required by or1k-tests
-RUN fusesoc init -y
-RUN fusesoc library add mor1kx-generic https://github.com/stffrdhrn/mor1kx-generic.git
-RUN fusesoc library add intgen https://github.com/stffrdhrn/intgen.git
-                                                
+RUN make -j8                                          


### PR DESCRIPTION
Fusesoc cores required by or1k-tests should be used in the mor1kx repository to register the cores at the correct path.
Otherwise, it generates the following error : 
```
WARNING: Failed to register cores root '/tmp/.local/share/fusesoc/mor1kx-generic is not a directory'
WARNING: Failed to register cores root '/tmp/.local/share/fusesoc/intgen is not a directory'
ERROR: 'mor1kx-generic' or any of its dependencies requires 'mor1kx-generic', but this core was not found
2019-07-12T12:43:33+00:00
```
In reference to https://github.com/openrisc/mor1kx/pull/89 
CC @oleg-nenashev 